### PR TITLE
Third resubmission of milestone 1

### DIFF
--- a/proyectos/1.md
+++ b/proyectos/1.md
@@ -14,7 +14,7 @@
 |COBOS SUAREZ, CARLOS | [SIGA-Cloud](https://github.com/kcobos/SIGA-Cloud) | 0.0.8.R1 |
 |CORDOBA GOMEZ, JOSE ANTONIO | [CloudBanking](https://github.com/pepitoenpeligro/CloudBanking) | 0.2.2 |
 |CORTÉS SÁNCHEZ ARTURO  | [Crab-IoT](https://github.com/arturocs/crab-iot) | 0.2.2.**R3** |
-|DE LA FLOR BONILLA, ALVARO | [CoronaAlert](https://github.com/alvarodelaflor/CoronaAlert) | 1.2.1.**R2** |
+|DE LA FLOR BONILLA, ALVARO | [CoronaAlert](https://github.com/alvarodelaflor/CoronaAlert) | 1.3.0.**R3** |
 |ESCOTO CANALES, CARLOS DAVID | | |
 |FLORES CRESPO, PEDRO MANUEL | [EvaluaUGR](https://github.com/PedroMFC/EvaluaUGR) | 1.0.2|
 |GOMEZ MARTIN, ANGEL | [HarvestCCode](https://github.com/harvestcore/HarvestCCode) | 0.2.1.**R1** |

--- a/proyectos/1.md
+++ b/proyectos/1.md
@@ -14,7 +14,7 @@
 |COBOS SUAREZ, CARLOS | [SIGA-Cloud](https://github.com/kcobos/SIGA-Cloud) | 0.0.8.R1 |
 |CORDOBA GOMEZ, JOSE ANTONIO | [CloudBanking](https://github.com/pepitoenpeligro/CloudBanking) | 0.2.2 |
 |CORTÉS SÁNCHEZ ARTURO  | [Crab-IoT](https://github.com/arturocs/crab-iot) | 0.2.2.**R3** |
-|DE LA FLOR BONILLA, ALVARO | [CoronaAlert](https://github.com/alvarodelaflor/CoronaAlert) | 1.3.0.**R3** |
+|DE LA FLOR BONILLA, ALVARO | [CoronaAlert](https://github.com/alvarodelaflor/CoronaAlert) | 1.3.1.**R3** |
 |ESCOTO CANALES, CARLOS DAVID | | |
 |FLORES CRESPO, PEDRO MANUEL | [EvaluaUGR](https://github.com/PedroMFC/EvaluaUGR) | 1.0.2|
 |GOMEZ MARTIN, ANGEL | [HarvestCCode](https://github.com/harvestcore/HarvestCCode) | 0.2.1.**R1** |


### PR DESCRIPTION
# Entrega del hito de Cloud Computing

Corresponde al hito 1

## Primero y más importante

* [x] Prometo no cerrar *nunca* un PR
* [x] ... ni eliminar mi repo si el PR va mal ...
* [x] ... ni abrir 2 PRs de lo mismo.

## Lista de comprobación para hitos

* [x] He leído el guión del hito
* [x] Cumplo los prerrequisitos (he aprobado el hito anterior, por ejemplo)
* [x] He actualizado con la última versión del fichero de entrega (y resto del repositorio).
* [x] He [seguido las instrucciones para reenvíos](https://jj.github.io/CC/documentos/proyecto/Reenvios) *sólo en caso de reenvío*.

## Descripción de la entrega

En primer lugar, y uno de los elementos más importantes de este reenvío es la creación de archivo en el que se justifica, desde el punto de vista de un programador, la creación de cada un de las clases que se van a utilizar ([#issue1](https://github.com/alvarodelaflor/CoronaAlert/commit/6da7e82af6ba690ca2e81e748660b921a97b84f4#diff-a4e9c6ddfcbf43ffe0db22c79529c574b52e422d7cf981cb6ebdc69c3c98e044)). Puede ver este archivo pulsando en este [enlace](https://github.com/alvarodelaflor/CoronaAlert/blob/master/Documentation/problem_justification.md).

Como consecuencia de este estudio, se han eliminado 2  entidades que se han considerado tras este completamente innecesarias (Classroom & subject). ([#issue2](https://github.com/alvarodelaflor/CoronaAlert/issues/39))

Como consecuencia de todo lo anterior se ha tenido que realizar una reestructuración completa de todo el código, así como volver a configurar todos los hitos que se habían propuesto. Para ello se han realizado varias issues para solventarlo. ([#issue3](https://github.com/alvarodelaflor/CoronaAlert/issues/43), [#issue4](https://github.com/alvarodelaflor/CoronaAlert/issues/44), [#issue5](https://github.com/alvarodelaflor/CoronaAlert/issues/40) ...)

Se ha configurado la clase asistencia para que ahora registre a todos los alumnos que asistan de forma grupal, en lugar de individual como se realizaba anteriormente (véase la justificación desde el punto de vista de un programador descrito anteriormente). Además en este registro se tiene en cuenta la posición del usuario, como se recomendó en la rúbrica ([#issue5](https://github.com/alvarodelaflor/CoronaAlert/issues/45)).

Se ha hecho una distinción entre los tipos de persona, para que a partir de este momento la única persona que registre una asistencia sea un profesor ([#issue6](https://github.com/alvarodelaflor/CoronaAlert/issues/46)).




